### PR TITLE
Fix JSON gem 1.8 vs 2.3 retrocompatibilty issue

### DIFF
--- a/lib/coinbase/exchange/api_client.rb
+++ b/lib/coinbase/exchange/api_client.rb
@@ -310,6 +310,8 @@ module Coinbase
         http_verb('POST', path, params.to_json) do |resp|
           begin
             out = JSON.parse(resp.body)
+            # JSON gem 1.8 vs 2.3 retrocompatibilty issue 
+            raise JSON::ParserError if out.nil?
           rescue JSON::ParserError
             out = resp.body
           end
@@ -323,6 +325,8 @@ module Coinbase
         http_verb('DELETE', path) do |resp|
           begin
             out = JSON.parse(resp.body)
+            # JSON gem 1.8 vs 2.3 retrocompatibilty issue 
+            raise JSON::ParserError if out.nil?
           rescue
             out = resp.body
           end

--- a/lib/coinbase/exchange/api_client.rb
+++ b/lib/coinbase/exchange/api_client.rb
@@ -285,6 +285,8 @@ module Coinbase
         http_verb('GET', "#{path}?#{URI.encode_www_form(params)}") do |resp|
           begin
             out = JSON.parse(resp.body)
+            # JSON gem 1.8 vs 2.3 retrocompatibilty issue 
+            raise JSON::ParserError if out.nil?
           rescue JSON::ParserError
             out = resp.body
           end

--- a/lib/coinbase/exchange/version.rb
+++ b/lib/coinbase/exchange/version.rb
@@ -1,6 +1,6 @@
 module Coinbase
   # Gem version
   module Exchange
-    VERSION = "0.2.2"
+    VERSION = "0.2.3"
   end
 end


### PR DESCRIPTION
`JSON.parse("null")` doesn't return the same result.